### PR TITLE
Update init.qcom.rc

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -65,6 +65,12 @@ on init
     symlink /storage/usbdisk /usbdisk
     symlink /storage/usbdisk /mnt/usbdisk
 
+on fs
+    mount_all fstab.qcom
+
+    restorecon_recursive /efs
+    restorecon_recursive /persist
+
 on early-boot
     # set RLIMIT_MEMLOCK to 64MB
     setrlimit 8 67108864 67108864


### PR DESCRIPTION
http://forum.xda-developers.com/showpost.php?p=60442240&postcount=81

Droidphilev reported about messed up permissions on efs partition which blocked his bluetooth pairing.
restorecon could help.
